### PR TITLE
Add metadata cache for Snowflake column lookups

### DIFF
--- a/docs/metadata-cache-relatorio.md
+++ b/docs/metadata-cache-relatorio.md
@@ -1,0 +1,56 @@
+# Relatório de alterações – Cache de metadados
+
+## Contexto geral
+- Todas as tasks do conector consultavam o Snowflake em cada inicialização usando `DatabaseMetaData.getColumns()` para descobrir a estrutura das tabelas alvo.
+- As listas de colunas eram reutilizadas durante o `flush` para gerar os arquivos CSV, montar `COPY INTO`, `MERGE` e `DELETE`.
+- Em clusters com criação frequente de conectores, o custo dessas chamadas crescia linearmente.
+- A mudança introduz um cache em memória por JVM, evitando chamadas repetidas para o mesmo par `schema.tabela` dentro do mesmo processo.
+
+---
+
+## Conector v3 (`br.com.datastreambrasil.v3`)
+
+### Antes
+- `AbstractProcessor.configMetadata()` chamava `getColumnsFromMetadata()` para a tabela final e para a tabela `_INGEST`.
+- Cada chamada abria um `ResultSet` via JDBC e removia as colunas configuradas em `ignore_columns` antes de devolver o resultado.
+- No `flush`, `columnsIngestTable` definia a ordem das colunas do CSV e do `COPY INTO` da tabela `_INGEST`; `columnsFinalTable` alimentava as instruções `MERGE` e `DELETE` contra a tabela destino.
+- Como não havia cache, cada start/restart da task repetia duas consultas de metadata no Snowflake.
+
+### Depois
+- `configMetadata()` agora chama `resolveColumns(...)`, que busca as colunas pelo utilitário compartilhado `MetadataCache` e aplica os filtros (`ignore_columns`) localmente.
+- O método `fetchColumnsFromMetadata()` só executa a consulta JDBC se o cache estiver vazio para aquele `schema.tabela`.
+- A lista devolvida é imutável e mantém deduplicação para preservar a ordem do Snowflake.
+- No `flush` nada muda funcionalmente: as listas continuam guiando a composição do CSV, do `COPY INTO`, do `MERGE` e do `DELETE`. A diferença é que, após a primeira leitura, as próximas tasks reutilizam o resultado em memória.
+
+### Impacto no Snowflake
+- Redução imediata de chamadas `DatabaseMetaData.getColumns()` para cada tabela final/_INGEST dentro da mesma JVM.
+- Apenas a primeira task que inicializa após o start do processo consulta o Snowflake; as demais usam o cache e iniciam mais rápido.
+- As consultas ainda acontecem quando uma tabela é acessada pela primeira vez em um novo worker ou após reiniciar o processo (cache em memória).
+
+---
+
+## Conector v2 (`br.com.datastreambrasil.v2`)
+
+### Antes
+- `SnowflakeSinkTask.start()` abria a conexão JDBC e chamava `getColumnsFromMetadata()` para preencher `columnsFinalTable`.
+- O método fazia uma consulta ao metadata do Snowflake, convertia os nomes de coluna para maiúsculas e removia itens de `ignore_columns`.
+- Durante o `flush`, a lista era usada para ordenar as colunas do CSV em memória e montar o comando `COPY INTO` da tabela final.
+- Cada criação/restart de task executava novamente a consulta `getColumns()` no Snowflake.
+
+### Depois
+- O carregamento é feito por `resolveColumnsFromMetadata()`, que delega ao `MetadataCache` e aplica filtros (`ignore_columns`) sobre o resultado cacheado.
+- `fetchColumnsFromMetadata()` só consulta o JDBC quando o cache não tem entrada para o par `schema.tabela` e continua retornando os nomes em maiúsculas.
+- A lista retornada é imutável e mantém a mesma ordem observada no metadata.
+- O uso no `flush` permanece inalterado: a lista define a ordem do CSV e compõe o `COPY INTO`, porém reaproveitando o metadata em memória após a primeira leitura por processo.
+
+### Impacto no Snowflake
+- Diminuição do número de consultas `DatabaseMetaData.getColumns()` por tabela final a partir da segunda task iniciada na mesma JVM.
+- Menor tempo de start para tasks subsequentes, já que a descoberta de colunas passa a ser local.
+- Assim como na v3, qualquer alteração de schema exige reinicializar o processo ou limpar o cache para refletir a nova estrutura.
+
+---
+
+## Considerações gerais
+- O cache é isolado por processo/JVM: múltiplos workers ainda fazem uma consulta inicial cada.
+- A política de invalidação continua sendo reiniciar o worker (não há limpeza automática no código atual).
+- Foram adicionados testes unitários para garantir que apenas a primeira tarefa aciona o metadata do Snowflake e que os filtros de colunas permanecem corretos em v2 e v3.

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
             <version>5.13.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.13.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- tests -->
 
         <dependency>
@@ -101,6 +107,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/br/com/datastreambrasil/common/MetadataCache.java
+++ b/src/main/java/br/com/datastreambrasil/common/MetadataCache.java
@@ -1,0 +1,75 @@
+package br.com.datastreambrasil.common;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Simple in-memory cache used to avoid repeating expensive metadata lookups in Snowflake.
+ */
+public final class MetadataCache {
+
+    private MetadataCache() {
+    }
+
+    private static final ConcurrentMap<MetadataKey, List<String>> CACHE = new ConcurrentHashMap<>();
+
+    @FunctionalInterface
+    public interface SqlSupplier<T> {
+        T get() throws SQLException;
+    }
+
+    public static List<String> getOrLoad(String schemaName, String tableName, SqlSupplier<List<String>> loader)
+        throws SQLException {
+        Objects.requireNonNull(schemaName, "schemaName");
+        Objects.requireNonNull(tableName, "tableName");
+
+        var key = new MetadataKey(schemaName, tableName);
+        try {
+            return CACHE.computeIfAbsent(key, ignored -> {
+                try {
+                    var loaded = loader.get();
+                    if (loaded == null || loaded.isEmpty()) {
+                        throw new IllegalStateException(
+                            "Empty columns returned from target table " + tableName + ", schema " + schemaName);
+                    }
+                    return Collections.unmodifiableList(new ArrayList<>(loaded));
+                } catch (SQLException e) {
+                    throw new MetadataLoadException(e);
+                }
+            });
+        } catch (MetadataLoadException e) {
+            throw e.getCause();
+        }
+    }
+
+    public static void clear() {
+        CACHE.clear();
+    }
+
+    private record MetadataKey(String schemaName, String tableName) {
+        private MetadataKey {
+            schemaName = schemaName.toUpperCase(Locale.ROOT);
+            tableName = tableName.toUpperCase(Locale.ROOT);
+        }
+    }
+
+    private static final class MetadataLoadException extends RuntimeException {
+        private final SQLException cause;
+
+        private MetadataLoadException(SQLException cause) {
+            super(cause);
+            this.cause = cause;
+        }
+
+        @Override
+        public SQLException getCause() {
+            return cause;
+        }
+    }
+}

--- a/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
+++ b/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
@@ -15,12 +15,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.UUID;
+import br.com.datastreambrasil.common.MetadataCache;
 import net.snowflake.client.jdbc.SnowflakeConnection;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -135,7 +137,7 @@ public class SnowflakeSinkTask extends SinkTask {
             snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
 
             //fill columns
-            columnsFinalTable = getColumnsFromMetadata(tableName);
+            columnsFinalTable = resolveColumnsFromMetadata(tableName);
 
             // job quartz config
             if (!disableCleanUpJob) {
@@ -379,7 +381,18 @@ public class SnowflakeSinkTask extends SinkTask {
         return false;
     }
 
-    private List<String> getColumnsFromMetadata(String table) throws SQLException {
+    List<String> resolveColumnsFromMetadata(String table) throws SQLException {
+        var rawColumns = MetadataCache.getOrLoad(schemaName, table, () -> fetchColumnsFromMetadata(table));
+        var filteredColumns = rawColumns.stream()
+            .filter(column -> !ignoreColumns.contains(column))
+            .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+
+        LOGGER.debug("Columns mapped from target table: {}", String.join(",", filteredColumns));
+
+        return List.copyOf(filteredColumns);
+    }
+
+    private List<String> fetchColumnsFromMetadata(String table) throws SQLException {
         var metadata = connection.getMetaData();
 
         var columnsFromTable = new ArrayList<String>();
@@ -392,10 +405,6 @@ public class SnowflakeSinkTask extends SinkTask {
             throw new RuntimeException(
                     "Empty columns returned from target table " + table + ", schema " + schemaName);
         }
-
-        columnsFromTable.removeAll(ignoreColumns);
-
-        LOGGER.debug("Columns mapped from target table: {}", String.join(",", columnsFromTable));
 
         return columnsFromTable;
     }

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -1,5 +1,6 @@
 package br.com.datastreambrasil.v3;
 
+import br.com.datastreambrasil.common.MetadataCache;
 import br.com.datastreambrasil.v3.model.SnowflakeRecord;
 import net.snowflake.client.jdbc.SnowflakeConnection;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -15,9 +16,11 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public abstract class AbstractProcessor {
 
@@ -74,8 +77,8 @@ public abstract class AbstractProcessor {
 
     protected void configMetadata() {
         try {
-            columnsFinalTable = getColumnsFromMetadata(tableName);
-            columnsIngestTable = getColumnsFromMetadata(ingestTableName);
+            columnsFinalTable = resolveColumns(tableName);
+            columnsIngestTable = resolveColumns(ingestTableName);
         } catch (SQLException e) {
             LOGGER.error("Error while get metadata columns from snowflake", e);
             throw new RuntimeException("Error while get metadata columns from snowflake", e);
@@ -108,7 +111,18 @@ public abstract class AbstractProcessor {
         }
     }
 
-    private List<String> getColumnsFromMetadata(String table) throws SQLException {
+    private List<String> resolveColumns(String table) throws SQLException {
+        var rawColumns = MetadataCache.getOrLoad(schemaName, table, () -> fetchColumnsFromMetadata(table));
+        var filteredColumns = rawColumns.stream()
+            .filter(column -> !ignoreColumns.contains(column))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        LOGGER.debug("Columns mapped from target table: {}", String.join(",", filteredColumns));
+
+        return List.copyOf(filteredColumns);
+    }
+
+    private List<String> fetchColumnsFromMetadata(String table) throws SQLException {
         var metadata = connection.getMetaData();
 
         var columnsFromTable = new ArrayList<String>();
@@ -122,13 +136,6 @@ public abstract class AbstractProcessor {
                 "Empty columns returned from target table " + table + ", schema " + schemaName);
         }
 
-        columnsFromTable.removeAll(ignoreColumns);
-        //remove duplicated
-        var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
-
-        LOGGER.debug("Columns mapped from target table: {}", String.join(",", columnsNoDuplicate));
-
-
-        return columnsNoDuplicate;
+        return columnsFromTable;
     }
 }

--- a/src/test/java/br/com/datastreambrasil/v2/SnowflakeSinkTaskMetadataCacheTest.java
+++ b/src/test/java/br/com/datastreambrasil/v2/SnowflakeSinkTaskMetadataCacheTest.java
@@ -1,0 +1,73 @@
+package br.com.datastreambrasil.v2;
+
+import br.com.datastreambrasil.common.MetadataCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SnowflakeSinkTaskMetadataCacheTest {
+
+    @BeforeEach
+    void resetCache() {
+        MetadataCache.clear();
+    }
+
+    @Test
+    void shouldReuseMetadataFromCache() throws Exception {
+        var connectionA = mock(Connection.class);
+        var metadataA = mock(DatabaseMetaData.class);
+        var resultSet = mock(ResultSet.class);
+
+        when(connectionA.getMetaData()).thenReturn(metadataA);
+        when(metadataA.getColumns(null, "PUBLIC", "CUSTOMER", null)).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString("COLUMN_NAME")).thenReturn("ID", "UPDATED_AT");
+
+        var taskA = new SnowflakeSinkTask();
+        setField(taskA, "connection", connectionA);
+        setField(taskA, "schemaName", "public");
+        addIgnoreColumn(taskA, "UPDATED_AT");
+
+        var columns = taskA.resolveColumnsFromMetadata("customer");
+        assertEquals(List.of("ID"), columns);
+
+        verify(metadataA, times(1)).getColumns(null, "PUBLIC", "CUSTOMER", null);
+
+        var connectionB = mock(Connection.class, invocation -> {
+            throw new AssertionError("Metadata should not be fetched again");
+        });
+
+        var taskB = new SnowflakeSinkTask();
+        setField(taskB, "connection", connectionB);
+        setField(taskB, "schemaName", "public");
+        addIgnoreColumn(taskB, "UPDATED_AT");
+
+        var cachedColumns = taskB.resolveColumnsFromMetadata("customer");
+        assertEquals(List.of("ID"), cachedColumns);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = SnowflakeSinkTask.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void addIgnoreColumn(SnowflakeSinkTask task, String value) throws Exception {
+        Field field = SnowflakeSinkTask.class.getDeclaredField("ignoreColumns");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        var list = (List<String>) field.get(task);
+        list.add(value);
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorMetadataCacheTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorMetadataCacheTest.java
@@ -1,0 +1,98 @@
+package br.com.datastreambrasil.v3;
+
+import br.com.datastreambrasil.common.MetadataCache;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractProcessorMetadataCacheTest {
+
+    @BeforeEach
+    void setUp() {
+        MetadataCache.clear();
+    }
+
+    @Test
+    void shouldReuseCachedMetadataAcrossProcessors() throws Exception {
+        var firstConnection = mock(Connection.class);
+        var firstMetadata = mock(DatabaseMetaData.class);
+        var finalResultSet = mock(ResultSet.class);
+        var ingestResultSet = mock(ResultSet.class);
+
+        when(firstConnection.getMetaData()).thenReturn(firstMetadata);
+        when(firstMetadata.getColumns(null, "PUBLIC", "CUSTOMER", null)).thenReturn(finalResultSet);
+        when(firstMetadata.getColumns(null, "PUBLIC", "CUSTOMER_INGEST", null)).thenReturn(ingestResultSet);
+
+        when(finalResultSet.next()).thenReturn(true, true, true, false);
+        when(finalResultSet.getString("COLUMN_NAME")).thenReturn("ID", "UPDATED_AT", "ID");
+        when(ingestResultSet.next()).thenReturn(true, false);
+        when(ingestResultSet.getString("COLUMN_NAME")).thenReturn("ID");
+
+        var processorA = new TestProcessor();
+        processorA.connection = firstConnection;
+        processorA.schemaName = "public";
+        processorA.tableName = "customer";
+        processorA.ingestTableName = "customer_ingest";
+        processorA.ignoreColumns.add("UPDATED_AT");
+
+        processorA.configMetadata();
+
+        assertIterableEquals(List.of("ID"), processorA.columnsFinalTable);
+        assertIterableEquals(List.of("ID"), processorA.columnsIngestTable);
+
+        verify(firstMetadata, times(1)).getColumns(null, "PUBLIC", "CUSTOMER", null);
+        verify(firstMetadata, times(1)).getColumns(null, "PUBLIC", "CUSTOMER_INGEST", null);
+
+        var secondConnection = mock(Connection.class, invocation -> {
+            throw new AssertionError("Metadata should not be fetched again");
+        });
+
+        var processorB = new TestProcessor();
+        processorB.connection = secondConnection;
+        processorB.schemaName = "public";
+        processorB.tableName = "customer";
+        processorB.ingestTableName = "customer_ingest";
+        processorB.ignoreColumns.add("UPDATED_AT");
+
+        processorB.configMetadata();
+
+        assertEquals(List.of("ID"), processorB.columnsFinalTable);
+        assertEquals(List.of("ID"), processorB.columnsIngestTable);
+    }
+
+    private static final class TestProcessor extends AbstractProcessor {
+
+        @Override
+        protected void extraConfigsOnStart(AbstractConfig config) {
+        }
+
+        @Override
+        protected void put(Collection<SinkRecord> collection) {
+        }
+
+        @Override
+        protected void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        }
+
+        @Override
+        protected void stop() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared in-memory metadata cache to reuse column lists between connector tasks
- refactor v2 and v3 processors to consume the cache while keeping per-task column filters intact
- document the behavioural changes for each connector version and add unit tests covering the cache behaviour

## Testing
- `mvn test` *(fails: Non-resolvable import POM: org.apache.logging.log4j:log4j-bom due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0cd6e2208330927ee9a26f5415d3